### PR TITLE
パンくず機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,7 @@ gem 'google_custom_search_api'
 gem 'google-api-client', '~> 0.34', :require => 'google/apis/customsearch_v1'
 gem 'devise'
 gem "aws-sdk-s3", require: false
+gem 'gretel'
 
 group :production do
   gem 'unicorn', '5.4.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,9 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (~> 0.14)
+    gretel (4.2.0)
+      actionview (>= 5.1, < 7.0)
+      railties (>= 5.1, < 7.0)
     httparty (0.18.1)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
@@ -397,6 +400,7 @@ DEPENDENCIES
   faker
   google-api-client (~> 0.34)
   google_custom_search_api
+  gretel
   image_processing (~> 1.2)
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)

--- a/app/assets/stylesheets/shared/share.css
+++ b/app/assets/stylesheets/shared/share.css
@@ -45,6 +45,22 @@
 
 .link-to {
   text-decoration: none;
-  color: black;
+  color: blue;
   font-size: 25px;
+}
+
+/* breadcrumbs */
+.breadcrumbs {
+  margin-top: 20px;
+  text-align: center;
+  color: black;
+}
+
+.breadcrumbs a {
+  text-decoration: none;
+  color: blue;
+}
+
+.breadcrumbs span {
+  font-weight: bold;
 }

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -29,3 +29,4 @@
       </div>
     <% end %>
 </div>
+<% breadcrumb :root %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -49,3 +49,4 @@
     <% end %>
   </div>
 </div>
+<% breadcrumb :books %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,5 +11,6 @@
 
   <body>
     <%= yield %>
+    <%= breadcrumbs separator: " &rsaquo; " %>
   </body>
 </html>

--- a/app/views/pages/search.html.erb
+++ b/app/views/pages/search.html.erb
@@ -17,3 +17,4 @@
   </div>
   <%= link_to "元のページに戻る", book_page_path, class:"link-to" %>
 </div>
+<% breadcrumb :searches %>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -71,3 +71,4 @@
     <% end %>
   </div>
 </div>
+<% breadcrumb :pages %>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -14,3 +14,8 @@ crumb :pages do
   link "ページ", book_page_path
   parent :books
 end
+
+crumb :searches do
+  link "検索画面"
+  parent :pages
+end

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,16 @@
+
+crumb :root do
+  link "あなたの本棚", root_path
+end
+
+crumb :books do
+  cur_url = request.url
+  book_id = cur_url.match("books/([0-9]+)/")
+  link "本の詳細", "/#{book_id}"
+  parent :root
+end
+
+crumb :pages do
+  link "ページ", book_page_path
+  parent :books
+end


### PR DESCRIPTION
# What
パンくずリストの追加

# Why
ユーザーが現在のページ同士の関係を把握しやすくするため。
ユーザーが容易にページ間を行き来しやす仕様にするため。